### PR TITLE
Fix issue #232: don't allow users joining a game in progress to start (reset) that game already in progress

### DIFF
--- a/Tetris/ClientApp/src/MultiplayerGame.js
+++ b/Tetris/ClientApp/src/MultiplayerGame.js
@@ -223,7 +223,11 @@ export const MultiplayerGame = ({ shapeProvider }) => {
                                 </CommandButton>
                             </div>
                             <div style={{ marginTop: "1rem" }}>
-                                <CommandButton onClick={startGame} runningText="Starting..." className="btn btn-primary">
+                                <CommandButton
+                                    disabled={gameEndTime > 0}
+                                    onClick={startGame}
+                                    runningText="Starting..."
+                                    className="btn btn-primary">
                                     Start Game
                                 </CommandButton>
                             </div>


### PR DESCRIPTION
Don't allow users that joined an already running game to start (reset) the game that's already in progress.